### PR TITLE
fix : mainpage의 centerview가 뷰포트 height의 남은 부분 전체를 차지하지 못하는 오류 수정

### DIFF
--- a/src/components/common/TopNav/TopNav.module.scss
+++ b/src/components/common/TopNav/TopNav.module.scss
@@ -5,7 +5,7 @@
 @include desktop {
   .navBox {
     width: 100%;
-    height: 3rem;
+    height: 100%;
 
     display: flex;
     flex-direction: row;

--- a/src/components/common/TopNav/TopNav.tsx
+++ b/src/components/common/TopNav/TopNav.tsx
@@ -43,6 +43,7 @@ const TopNav = () => {
             top: 0,
             left: 0,
             width: "100%",
+            height: "3rem",
             zIndex: 100,
           }}
           initial={{ y: -100, opacity: 0 }}

--- a/src/pages/main/centerview/CenterView.module.scss
+++ b/src/pages/main/centerview/CenterView.module.scss
@@ -1,24 +1,19 @@
 .page {
   width: 100%;
   min-width: 351px;
-  height: 100vh;
+  height: 100dvh;
 
   display: flex;
   flex-direction: column;
 
-  overflow-y: scroll;
-
   &__contents {
     width: 100%;
-    min-height: 0;
-    height: 100vh;
-    overflow-y: auto;
-
+    height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: start;
+    justify-content: space-between;
     align-items: center;
-    flex: 1;
+
     @include desktop {
       padding-top: 3rem;
     }

--- a/src/pages/main/centerview/CenterView.tsx
+++ b/src/pages/main/centerview/CenterView.tsx
@@ -39,21 +39,13 @@ const CenterView = () => {
         </div>
         <div className={styles.page__contents__creditSection}>
           <div className={styles.page__contents__creditSection__contents}>
-            <div
-              className={styles.page__contents__creditSection__contents__item}
-              onClick={() => navigate("/privacy")}
-            >
+            <div className={styles.page__contents__creditSection__contents__item} onClick={() => navigate("/privacy")}>
               개인정보 처리방침
             </div>
-            <div
-              className={styles.page__contents__creditSection__contents__item}
-              onClick={() => navigate("/tos")}
-            >
+            <div className={styles.page__contents__creditSection__contents__item} onClick={() => navigate("/tos")}>
               이용약관
             </div>
-            <div className={styles.page__contents__creditSection__contents__item}>
-              ©RunningMate ALL RIGHTS RESERVED
-            </div>
+            <div className={styles.page__contents__creditSection__contents__item}>©RunningMate ALL RIGHTS RESERVED</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#49 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 상단 내비게이션 바 높이를 3rem로 고정해 레이아웃 안정성과 가시성을 개선했습니다. 데스크톱 환경에서 높이 처리 조정으로 빈 공간/겹침 가능성을 완화했습니다.
  - CenterView의 화면 높이를 동적 뷰포트(100dvh)로 변경해 모바일 주소창 표시 변화에도 안정적인 화면 높이를 제공합니다. 페이지/콘텐츠 영역의 스크롤과 높이를 재조정해 이중 스크롤을 제거하고, 섹션 수축을 방지하며 영역 간 배치를 더 균형 있게 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->